### PR TITLE
changed comparision to use < instead of >

### DIFF
--- a/3-algorithms/sorting/bubble-sort.cpp
+++ b/3-algorithms/sorting/bubble-sort.cpp
@@ -17,7 +17,7 @@ void bubble_sort(ForwardRange& range)
 		for (iterator i = begin; std::next(i) != end; std::advance(i, 1)) {
 			iterator next = std::next(i);
 
-			if (*i > *next) {
+			if (*next < *i) {
 				std::iter_swap(i, next);
 				new_end = next;
 			}


### PR DESCRIPTION
It is STL-convention to rely on the operator< (often used in std::less<T>) by default.
