### PR TITLE
Added a concurrency section, with examples

### DIFF
--- a/1-common-tasks/concurrency/TITLE
+++ b/1-common-tasks/concurrency/TITLE
@@ -1,0 +1,1 @@
+Concurrency

--- a/1-common-tasks/concurrency/acquiring-multiple-locks.cpp
+++ b/1-common-tasks/concurrency/acquiring-multiple-locks.cpp
@@ -1,0 +1,110 @@
+// Acquire multiple locks
+// C++11
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <iostream>
+#include <mutex>
+#include <thread>
+
+struct account
+{
+	double balance = 0.0;
+	std::mutex mutex;
+};
+
+void transfer(account& fr_acct, account& to_acct, double amount)
+{
+	std::lock(fr_acct.mutex, to_acct.mutex);
+	std::lock_guard<std::mutex> fr_acct_lock{fr_acct.mutex, std::adopt_lock};
+	std::lock_guard<std::mutex> to_acct_lock{to_acct.mutex, std::adopt_lock};
+	
+	fr_acct.balance -= amount;
+	to_acct.balance += amount;
+}
+
+constexpr int num_payments = 3;
+
+void do_transfers(account& f, account& t,
+		std::array<double, num_payments> payments)
+{
+	std::for_each(std::begin(payments), std::end(payments),
+		[&f, &t](double a) { transfer(f, t, a); });
+}
+
+int main()
+{
+	account acct_1;
+	account acct_2;
+	
+	acct_1.balance = 1000.0;
+	acct_2.balance = 1000.0;
+	
+	std::array<double, num_payments> payments_1 = { 923.54, -453.19, 501.01 };
+	std::array<double, num_payments> payments_2 = { 268.44, 840.19, -733.15 };
+	
+	std::thread t1{do_transfers, std::ref(acct_1), std::ref(acct_2), payments_1};
+	std::thread t2{do_transfers, std::ref(acct_2), std::ref(acct_1), payments_2};
+	
+	t1.join();
+	t2.join();
+	
+	std::cout << "Account 1 balance = " << acct_1.balance << '\n';
+	std::cout << "Account 2 balance = " << acct_2.balance << '\n';
+}
+
+// Acquire multiple locks safely.
+// 
+// We should always be wary of locks in code. While they are usually
+// a necessary evil, they are often cause performance bottlenecks
+// and - worse - can lead to deadlocks if we are not very careful.
+// 
+// On [17-25] we have a function that transfers funds between two
+// accounts. If this is a large system with millions of accounts and
+// thousands of transactions happening every second, we wouldn't want
+// to use a global lock - we couldn't afford to lock up the entire
+// bank for every single transaction. Instead, we handle
+// synchronization on a per-account basis; each account has its own
+// mutex, and we only lock the ones we are working with at the moment.
+// Other transactions involving other accounts can continue
+// concurrently.
+// 
+// Suppose we tried to lock the mutexes in the two accounts involved
+// in the transaction individually - first we lock `fr_acct`, then
+// `to_acct`. Notice that on [47-48], we have two threads each doing
+// transfers with those two accounts, but `t1` is doing transactions
+// *from* account 1 *to* account 2, while `t2` is doing them *to*
+// account 1 *from* account 2. That means that the `transfer()`
+// function in `t1` locks account 1 first, then account 2; while `t2`
+// locks account 2 first, then account 1. Imagine that `t1` is
+// running, and it locks account 1, then gets halted by the operating
+// system. While `t1` is waiting to be restarted, `t2` now comes
+// along, locks account 2, then tries to lock account 1. `t2`
+// discovers that some other thread (`t1`) already has a lock on it,
+// so it blocks and waits for that other thread to release its lock on
+// account 1. But *then* `t1` is allowed to run again, and it
+// continues what it was doing, and tries to lock account 2. Now `t1`
+// discovers that account 2 is already locked by another thread
+// (`t2`). So it blocks and waits for it. See what's happened? `t1`
+// owns the lock on account 1, and is waiting for account 2... `t2`
+// owns the lock on account 2, and is waiting for account 1. Deadlock.
+// 
+// [`std::lock()`](cpp/thread/lock) prevents this from happening. It
+// can take any number of lockable objects (like mutexes), and safely
+// acquire locks on all of them. If we always use `std::lock()` to
+// lock multiple mutexes, we will never have to worry about order of
+// acquisition deadlocks.
+// 
+// First we acquire all the locks with `std::lock()` on [19]. When
+// `std::lock()` returns, we own *all* the locks. Then we create
+// [`std::lock_guard`](cpp/thread/lock_guard) objects for each lock
+// ([20-21]) - we want to do this because `std::lock_guard`s are safe,
+// RAII lock owner objects that will do the right thing even if an
+// exception is thrown. The trick is to have the `std::lock_guard`s
+// take over ownership of the locks *without unlocking them*; to do
+// that we use the [`std::adopt_lock`](cpp/thread/lock_tag) tag.
+// 
+// Once all that is done, we can safely do our updates to both
+// accounts ([23-24]). The locks get released automatically when the
+// function exits.

--- a/1-common-tasks/concurrency/async.cpp
+++ b/1-common-tasks/concurrency/async.cpp
@@ -1,0 +1,67 @@
+// Concurrent tasks
+// C++11
+
+#include <chrono>
+#include <exception>
+#include <future>
+#include <iostream>
+#include <utility>
+
+int func(int a, int b)
+{
+	// Delay a bit
+	std::this_thread::sleep_for(std::chrono::seconds{3});
+	
+	// Uncomment the following line to try an error
+	//throw std::runtime_error{"error calculating answer"};
+	
+	return a * b;
+}
+
+int main()
+{
+	std::future<int> answer = std::async(func, 6, 7);
+	// Or, if we want to request that func is executed concurrently:
+	//std::future<int> answer = std::async(std::launch:async, func, 6, 7);
+	
+	try
+	{
+		auto ans = answer.get();
+		std::cout << "The answer is " << ans << '\n';
+	}
+	catch (std::exception const& x)
+	{
+		std::cerr << x.what() << '\n';
+	}
+}
+
+// Execute a task concurrently.
+// 
+// While we could use `std::thread` and `std::promise` (or perhaps
+// `std::thread` and `std::packaged_task`) to cobble together a way to
+// run tasks concurrently, [`std::async`](cpp/thread/async) is a
+// higher-level way to accomplish this.
+// 
+// On [23] we call `std::async` with `func` as the first argument, and
+// the arguments we want passed to `func` as the remaining arguments.
+// (Note that all arguments will be passed to `func` by value, which
+// means copying or moving. If we wanted to use any reference
+// arguments, we would have to use `std::ref` or `std::cref`.) We
+// capture the result as a future.
+// 
+// By default, `std::async` will decide whether to execute the task
+// concurrently, or to wait until we request the result and then
+// execute the task non-concurrently at that time. If we want to
+// specifically request one of those behaviours we can use a flag as
+// the first argument. To request concurrent execution (if possible),
+// we would use `std::launch::async`. To request that the task is
+// executed only when we need the result (non-concurrently), we
+// would use `std::launch::deferred`.
+// 
+// When we need the result on [29], we use the `get()` member function.
+// This blocks until the result is available, unless the task throws
+// an exception (in which case, the exception is rethrown in the
+// current thread).
+// 
+// (Note that it is important that we capture the future returned by
+// `std::async`. If we do not, then the call will always block.)

--- a/1-common-tasks/concurrency/concurrent-queue.cpp
+++ b/1-common-tasks/concurrency/concurrent-queue.cpp
@@ -1,0 +1,163 @@
+// Concurrent queue
+// C++11
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <iostream>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <string>
+#include <thread>
+
+template <typename T>
+class concurrent_queue
+{
+public:
+	void push(T t)
+	{
+		std::unique_lock<std::mutex> lock{mutex_};
+		queue_.push(std::move(t));
+		lock.unlock();
+		cond_.notify_one();
+	}
+	
+	T pop()
+	{
+		std::unique_lock<std::mutex> lock{mutex_};
+		cond_.wait(lock, [this]{ return !queue_.empty(); });
+		T temp = std::move(queue_.front());
+		queue_.pop();
+		return temp;
+	}
+	
+private:
+	std::mutex mutex_;
+	std::condition_variable cond_;
+	std::queue<T> queue_;
+};
+
+int const num_producers = 4;
+int const num_iterations = 5;
+
+void produce(concurrent_queue<std::string>& q)
+{
+	std::string s = []{
+		std::ostringstream oss;
+		oss << "thread " << std::this_thread::get_id();
+		return oss.str();
+	}();
+	
+	for (int i = 0; i < num_iterations; ++i)
+	{
+		q.push(s);
+		std::this_thread::sleep_for(std::chrono::milliseconds{100});
+	}
+}
+
+int main()
+{
+	concurrent_queue<std::string> q;
+	
+	std::vector<std::thread> producers(num_producers);
+	std::generate(std::begin(producers), std::end(producers),
+		[&q]{ return std::thread{produce, std::ref(q)}; });
+	
+	for (int i = 0; i < num_producers * num_iterations; ++i)
+		std::cout << q.pop() << '\n';
+	
+	std::for_each(std::begin(producers), std::end(producers),
+		[](std::thread& t) { t.join(); });
+}
+
+// Implement a basic concurrent queue.
+// 
+// [!15-40] illustrate a basic concurrent queue - a queue designed for
+// sharing a data stream between multiple threads.
+// 
+// The heart of the queue is a [`std::queue`](cpp/container/queue)
+// ([39]). To synchronize access to the queue, we need a
+// [`std::mutex`](cpp/thread/mutex) ([37]). A
+// [`std::condition_variable`](cpp/thread/condition_variable) ([38])
+// will help us send messages efficiently across threads.
+// 
+// In the push function on [19-25], we first attempt to acquire a lock
+// on the queue's mutex ([21]). This is is necessary, because we don't
+// want to try making any changes to `queue_` - or even attempting to
+// read it - while another thread might be in the process of changing
+// it. Once we have acquired the lock, we know we are the sole owners
+// of the queue object, so it is safe to make changes to it. So on
+// [22] we push the argument onto the end of the queue, then on [23]
+// we immediately relinquish the lock - we never want to hold a lock
+// any longer than we have to. After that, we send a notification to
+// one waiting thread (assuming there is any) to alert them that there
+// is an item in the queue.
+// 
+// In the pop function on [27-34], we begin again by acquiring the
+// lock ([29]). Then on [30], we ask the condition variable to wait
+// until the queue is not empty. The way this works is that the
+// condition variable first checks the test in the lambda, and if
+// that is false (if the queue *is* empty), it releases the lock and
+// then blocks until it is notified. When it receives a notification,
+// it reacquires the lock and checks the test again (because sometimes
+// there are phenomena called "spurious wakeups"). Once again, if the
+// test fails, the condition variable releases the lock and returns to
+// waiting. But if the test is true - in this case, if the queue is
+// not empty, wait returns (while keeping the lock on the mutex). So
+// when we get to [31], we know two things: we have acquired a lock on
+// `mutex_`, and `queue_` is not empty. Therefore we can safely move
+// from the object at the front of the queue ([31]), then remove it
+// from the queue ([32]), and return it ([33]). The lock is
+// automatically released when the function returns.
+// 
+// Because this is a very basic concurrent queue, there are a few
+// things to be cautious about.
+// 
+// This first thing to be cautious about is that the total number of
+// items pushed to the queue *must* be greater than or equal to the
+// number of pop attempts. If there is a pop attempt, and no other
+// threads are pushing items to the queue, that pop attempt will cause
+// a deadlock - it will forever wait for another item to be pushed to
+// the queue, even though no more are coming.
+// 
+// This problem can be fixed, but it requires either tolerating that
+// `pop()` might throw an exception when there will be no more items
+// coming, or redesigning the interface of `pop()`. Perhaps `pop()`
+// could return `std::optional<T>`, and the caller is required to
+// check the result.
+// 
+// The second thing to be cautious about: objects on the queue may be
+// lost forever in the pop function if their move assignment operator
+// can throw exceptions. To understand why, imagine we are on line
+// [32]. At this point, we have successfully moved the object at the
+// front of the queue into `temp` (which destroys the original in the
+// queue), and removed it from the queue entirely (on [33]). Now the
+// return statement tries to move from `temp` into the result object
+// in the caller... and then there's an exception. Even if you manage
+// to catch the exception in the caller, `temp` is lost. The original
+// object on the queue is also lost. So whatever that data was, it's
+// not gone, and cannot be recovered.
+// 
+// In reality, this problem is not as serious as it sounds. First, it
+// is generally good practice, for many reasons - and it is usually
+// possible to do - to make move operations non-throwing.
+// `std::string`, which we used in the example, has non-throwing move
+// ops. Second, because the function, as it is written, can leverage
+// named return value optimization, the `temp` variable will usually
+// be optimized away, so when the object is moved out of the front of
+// the queue it will be moved *directly* into the return value in the
+// caller. If that fails, then as long as the move assignment
+// operation has the strong exception guarantee, there will be no
+// problem - the move attempt will be rolled back as if it had never
+// been attempted at all. So the only *dangerous* types will be types
+// that a) have a throwing move assignment operator that b) offers
+// only the weak exception guarantee or worse. Types *that* twitchy
+// probably shouldn't be put in a concurrent queue in the first place.
+// In fact, types that have throwing move ops don't have to be
+// tolerated at all - if someone really wants to put them in a
+// concurrent queue, they can be wrapped in smart pointers. So perhaps
+// the best way to deal with this problem is to use a
+// `static_assert` to enforce
+// `std::is_nothrow_move_assignable<T>::value`.

--- a/1-common-tasks/concurrency/thread-arguments.cpp
+++ b/1-common-tasks/concurrency/thread-arguments.cpp
@@ -1,0 +1,60 @@
+// Thread arguments
+// C++11
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <thread>
+
+void func(long y, std::string n, int& answer, std::string const& q)
+{
+	// Let's not actually wait 7.5 million years...
+	std::chrono::seconds calculation_time{3};
+	std::this_thread::sleep_for(calculation_time);
+	
+	answer += 42;
+}
+
+int main()
+{
+	long years = 7500000;
+	std::string name = {"Deep Thought"};
+	std::string const question = {"What is the answer?"};
+	int answer = 0;
+	
+	std::thread t{func, years, name, std::ref(answer), std::cref(question)};
+	
+	std::cout << "Calculating the answer, please wait..." << std::endl;
+	
+	t.join();
+	
+	std::cout << "The answer is " << answer << '\n';
+}
+
+// Pass arguments to a thread function.
+// 
+// On [22], we create a [`std::thread`](cpp/thread/thread) object `t`.
+// In the constructor call, we pass `func` as the first argument - this
+// is the thread function. The remaining constructor arguments are
+// passed to `func`.
+// 
+// Arguments that are passed by value require no extra work - they are
+// simply copied (or moved) before the thread constructor returns.
+// 
+// Arguments that are passed by reference must be passed using
+// [`std::ref`](cpp/utility/functional/ref). Arguments passed by
+// `const` reference must be passed using
+// [`std::cref`](cpp/utility/functional/cref).
+// 
+// On [28], after the thread has completed, we can observe that the
+// value of `answer` has been changed (it was changed on [12], which
+// was executed in the other thread). This is a limited way of getting
+// a "return value" from a thread, but there are better ways.
+// 
+// (Note that while it is generally not recommended to use
+// `std::endl`, it is necessary to use it on [28]. This is because we
+// want to ensure the "please wait" message is flushed *immediately*
+// to the output - *before* `t.join()` blocks - rather than being
+// buffered and potentially not being displayed until after the delay
+// we wish to ask the user to wait through.)

--- a/1-common-tasks/concurrency/thread-returns.cpp
+++ b/1-common-tasks/concurrency/thread-returns.cpp
@@ -1,0 +1,69 @@
+// Thread return values
+// C++11
+
+#include <chrono>
+#include <exception>
+#include <future>
+#include <iostream>
+#include <thread>
+#include <utility>
+
+void func(std::promise<int> answer_promise) noexcept
+{
+	try
+	{
+		// Delay a bit
+		std::this_thread::sleep_for(std::chrono::seconds{3});
+		
+		// Uncomment the following line to try an error
+		//throw std::runtime_error{"error calculating answer"};
+		
+		answer_promise.set_value(42);
+	}
+	catch (...)
+	{
+		answer_promise.set_exception(std::current_exception());
+	}
+}
+
+int main()
+{
+	std::promise<int> answer_promise = {};
+	std::future<int> answer_future = answer_promise.get_future();
+	
+	std::thread t{func, std::move(answer_promise)};
+	
+	// ...
+	
+	try
+	{
+		auto answer = answer_future.get();
+		std::cout << "The answer is " << answer << '\n';
+	}
+	catch (std::exception const& x)
+	{
+		std::cerr << x.what() << '\n';
+	}
+	
+	t.join();
+}
+
+// Return values from a thread.
+// 
+// We could use reference arguments to return values from a thread
+// function, but futures are a better option. (Better still would be
+// using `async`.)
+// 
+// On [31] we create a [`std::promise`](cpp/thread/promise), and on
+// [32] we get a future from that promise before passing it (by
+// moving, because promises cannot be copied) to a thread.
+// 
+// In the thread function on [21], we set that promise to the return
+// value. Alternately, if there was an error, we could set the
+// promise's exception to indicate that.
+// 
+// On [40], we use the future's `get()` function to try to get the
+// promised return value. This function will block until there is a
+// value or an exception available. If there is a value, it is simply
+// returned. Alternately, if there was an exception stored, it is
+// thrown.

--- a/1-common-tasks/concurrency/thread.cpp
+++ b/1-common-tasks/concurrency/thread.cpp
@@ -1,0 +1,51 @@
+// Create a thread
+// C++11
+
+#include <thread>
+
+void func()
+{
+	// body
+}
+
+int main()
+{
+	std::thread t{func};
+	
+	// ...
+	
+	t.join();
+}
+
+// Create a thread.
+// 
+// On [9], we create a [`std::thread`](cpp/thread/thread) object `t`,
+// which represents an operating system thread (whatever that may mean
+// for the operating system it is running on).
+// 
+// A default-constructed `std::thread` object is empty - it does
+// nothing useful. So when constructing `t`, we pass a reference to
+// function `func`.
+// 
+// After creating the thread, the constructor returns immediately, and
+// the remainder of `main` continues to execute in the original
+// thread. At the same time (more or less, depending on system
+// scheduling), function `func` begins executing in the newly-created
+// thread. This means that, in theory, the body of `func` ([8]) and
+// the code in `main` ([14-16]) will be executing at the same time, in
+// parallel. (In reality, there are situations where this might not
+// happen, such as if the system does not support parallel execution.)
+// 
+// A thread that is not empty (that is, one that is not created with
+// the default `std::thread` constructor, or moved-from) must be
+// either detached or joined before destruction, or
+// [`std::terminate()`](cpp/error/terminate) will be called. Joining
+// is more common (detaching is dangerous), so on [17] we call `t`'s
+// [`join()`](cpp/thread/thread/join) function. This causes the
+// original thread (the one `main` is running in) to block until `t`'s
+// thread function (which is `func`) returns. (`func` must not let an
+// exception propagate out of its body, or `std::terminate` will be
+// called.)
+// 
+// Once `join()` returns, `t` is empty - the thread it represented is
+// gone - and control continues once more in the original thread.


### PR DESCRIPTION
I thought concurrency was a big enough topic that it deserved its own section. Included are six examples:
-   Creating a thread
-   Creating a thread and passing arguments to it
-   Getting a result back from a thread (`std::promise` and `std::future`)
-   High-level concurrent tasks (`std::async()`)
-   A simple concurrent queue (illustrating `std::mutex`, `std::unique_lock`, `std::condition_variable`)
-   Safely locking multiple locks (`std::lock()`)
