### PR TITLE
Fix line number references in sleep pattern description

### DIFF
--- a/common-tasks/time/sleep.cpp
+++ b/common-tasks/time/sleep.cpp
@@ -16,14 +16,14 @@ int main()
 
 // Block the execution of a thread for a given amount of time.
 //
-// On [10], we create a [`std::chrono::milliseconds`](cpp/chrono/duration)
+// On [11], we create a [`std::chrono::milliseconds`](cpp/chrono/duration)
 // object representing the number of milliseconds to sleep (other
-// duration units may also be used). On [11], the call to
+// duration units may also be used). On [12], the call to
 // [`std::this_thread::sleep_for`](cpp/thread/sleep_for) will block
 // the execution of the current thread for at least the given
 // duration.
 //
-// On [13], we demonstrate the use of C++14's [duration literal
+// On [14], we demonstrate the use of C++14's [duration literal
 // suffixes](http://en.cppreference.com/w/cpp/chrono/duration#Literals)
 // by representing a duration with the seconds suffix, `s`. The
 // `using` directive on [7] is required in order to use these suffixes.


### PR DESCRIPTION
Fix a set of off-by-one line references in the sleep pattern description.